### PR TITLE
Fetch price changes for tokens

### DIFF
--- a/components/Table/Columns.ts
+++ b/components/Table/Columns.ts
@@ -60,6 +60,7 @@ export const PriceChange: ListColumn<Token> = {
   disableGlobalFilter: true,
   sortType: 'basic',
   align: 'right',
+  colorBasedOnValue: true,
   Cell: Cells.ValuePercent,
 }
 

--- a/hooks/useMetaSubscription.ts
+++ b/hooks/useMetaSubscription.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+import { useSetRecoilState } from 'recoil'
+import { thegraphClientSub, MetaSubscription } from 'lib/graphql'
+import { currentBlockNumberState } from 'state/meta'
+import type { MetaQueryResponse } from 'types/trade'
+
+interface subReturnValue {
+  data: MetaQueryResponse
+}
+
+export default function useMetaSubscription(): void {
+  const setCurrentBlockNumber = useSetRecoilState(currentBlockNumberState)
+
+  useEffect(() => {
+    const subMeta = thegraphClientSub
+      .request({ query: MetaSubscription })
+      .subscribe({
+        next: ({ data }: subReturnValue) =>
+          setCurrentBlockNumber(data._meta.block.number),
+      })
+
+    return () => {
+      subMeta.unsubscribe()
+    }
+  }, [setCurrentBlockNumber])
+}

--- a/lib/block.ts
+++ b/lib/block.ts
@@ -1,0 +1,17 @@
+import { thegraphClient, MetaQuery } from 'lib/graphql'
+import type { MetaQueryResponse } from 'types/trade'
+
+export async function getCurrentBlockNumber(): Promise<number> {
+  try {
+    const response: MetaQueryResponse = await thegraphClient.request(MetaQuery)
+    return response._meta.block.number
+  } catch (e) {
+    console.error(e)
+    return 0
+  }
+}
+
+export async function getAverageBlockCountPerHour(): Promise<number> {
+  const estimatedBlocktime = 15 // seconds
+  return Math.floor(3600 / estimatedBlocktime)
+}

--- a/lib/graphql/index.ts
+++ b/lib/graphql/index.ts
@@ -3,6 +3,7 @@ import { SubscriptionClient } from 'graphql-subscriptions-client'
 
 const THEGRAPH_ENDPOINT = 'api.thegraph.com/subgraphs/name/uniswap/uniswap-v2'
 
+export * from './queries/meta'
 export * from './queries/tokens'
 
 export const thegraphClient = new GraphQLClient(`https://${THEGRAPH_ENDPOINT}`)

--- a/lib/graphql/queries/meta.ts
+++ b/lib/graphql/queries/meta.ts
@@ -1,0 +1,29 @@
+import { gql } from 'graphql-request'
+
+const MetaFragment = gql`
+  fragment Meta on _Meta_ {
+    block {
+      hash
+      number
+    }
+    deployment
+  }
+`
+
+export const MetaQuery = gql`
+  query {
+    _meta {
+      ...Meta
+    }
+  }
+  ${MetaFragment}
+`
+
+export const MetaSubscription = gql`
+  subscription {
+    _meta {
+      ...Meta
+    }
+  }
+  ${MetaFragment}
+`

--- a/lib/graphql/queries/tokens.ts
+++ b/lib/graphql/queries/tokens.ts
@@ -1,50 +1,87 @@
 import { gql } from 'graphql-request'
 
+const TokenCommonFragment = gql`
+  fragment TokenCommonFragment on Pair {
+    pairdId: id
+    reserveUSD
+  }
+`
+
+const TokenABFragment = gql`
+  fragment TokenABFragment on Pair {
+    token: token1 {
+      id
+    }
+    price: token0Price
+  }
+`
+
+const TokenBAFragment = gql`
+  fragment TokenBAFragment on Pair {
+    token: token0 {
+      id
+    }
+    price: token1Price
+  }
+`
+
 export const TokenInfoQuery = gql`
   query tokenInfo($weth: String, $tokenAddresses: [String]) {
     tokensAB: pairs(where: { token0: $weth, token1_in: $tokenAddresses }) {
-      pairId: id
-      reserveUSD
-      token: token1 {
-        id
-      }
-      price: token0Price
+      ...TokenCommonFragment
+      ...TokenABFragment
     }
     tokensBA: pairs(where: { token1: $weth, token0_in: $tokenAddresses }) {
-      pairId: id
-      reserveUSD
-      token: token0 {
-        id
-      }
-      price: token1Price
+      ...TokenCommonFragment
+      ...TokenBAFragment
     }
   }
+  ${TokenCommonFragment}
+  ${TokenABFragment}
+  ${TokenBAFragment}
+`
+export const TokenInfoQueryHistorical = gql`
+  query tokenInfo($blockNumber: Int, $weth: String, $tokenAddresses: [String]) {
+    tokensAB: pairs(
+      block: { number: $blockNumber }
+      where: { token0: $weth, token1_in: $tokenAddresses }
+    ) {
+      ...TokenCommonFragment
+      ...TokenABFragment
+    }
+    tokensBA: pairs(
+      block: { number: $blockNumber }
+      where: { token1: $weth, token0_in: $tokenAddresses }
+    ) {
+      ...TokenCommonFragment
+      ...TokenBAFragment
+    }
+  }
+  ${TokenCommonFragment}
+  ${TokenABFragment}
+  ${TokenBAFragment}
 `
 
 export const TokenInfoSubAB = gql`
   subscription tokenInfoAB($weth: String, $tokenAddresses: [String]) {
     tokens: pairs(where: { token0: $weth, token1_in: $tokenAddresses }) {
-      pairId: id
-      reserveUSD
-      token: token1 {
-        id
-      }
-      price: token0Price
+      ...TokenCommonFragment
+      ...TokenABFragment
     }
   }
+  ${TokenCommonFragment}
+  ${TokenABFragment}
 `
 
 export const TokenInfoSubBA = gql`
   subscription tokenInfoBA($weth: String, $tokenAddresses: [String]) {
     tokens: pairs(where: { token1: $weth, token0_in: $tokenAddresses }) {
-      pairId: id
-      reserveUSD
-      token: token0 {
-        id
-      }
-      price: token1Price
+      ...TokenCommonFragment
+      ...TokenBAFragment
     }
   }
+  ${TokenCommonFragment}
+  ${TokenBAFragment}
 `
 
 export const PairByIdQuery = gql`

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,6 +1,10 @@
 import uniswapTokens from '@uniswap/default-token-list'
 import Vibrant from 'node-vibrant'
-import { thegraphClient, TokenInfoQuery } from 'lib/graphql'
+import {
+  thegraphClient,
+  TokenInfoQuery,
+  TokenInfoQueryHistorical,
+} from 'lib/graphql'
 import { ipfsToHttp } from 'lib/ipfs'
 import type { Token, TokenInfoQueryResponse } from 'types/trade'
 
@@ -29,6 +33,7 @@ export function getAllTokens(): Token[] {
       logoColor: null,
       pairId: null,
       price: null,
+      priceHistorical: null,
       liquidity: null,
       priceChange: null,
     }))
@@ -56,9 +61,15 @@ export function addLogoColor(tokens: Token[]): Promise<Token[]> {
   )
 }
 
+function calcPriceChange(newPrice: number, oldPrice: number): number {
+  if (oldPrice === 0) return 0
+  return (newPrice - oldPrice) / oldPrice
+}
+
 export function addData(
   tokens: Token[],
   data: TokenInfoQueryResponse[],
+  historical = false,
 ): Token[] {
   return tokens.map((t) => {
     const d = data.find(
@@ -67,29 +78,47 @@ export function addData(
 
     if (!d) return t
 
+    const price = !historical ? parseFloat(d.price) : t.price ?? 0
+    const liquidity = !historical ? parseFloat(d.reserveUSD) : t.liquidity
+    const priceHistorical = historical ? parseFloat(d.price) : t.priceHistorical
+    const priceChange = priceHistorical
+      ? calcPriceChange(price, priceHistorical)
+      : 0
+
     return {
       ...t,
-      pairId: d.pairId,
-      price: parseFloat(d.price),
-      liquidity: parseFloat(d.reserveUSD),
-      priceChange: 0,
+      pairId: d.pairId ?? t.pairId,
+      price,
+      priceHistorical,
+      priceChange,
+      liquidity,
     }
   })
 }
 
-export async function addGraphInfo(tokens: Token[]): Promise<Token[]> {
+export async function addGraphInfo(
+  tokens: Token[],
+  blockNumber = 0,
+): Promise<Token[]> {
   if (!weth) {
     throw new Error(
       `Unable to find ${WETH} in uniswap list with "chainId": ${chainId}`,
     )
   }
 
+  const historical = blockNumber > 0
+
+  const query = !historical ? TokenInfoQuery : TokenInfoQueryHistorical
+
+  const variables = {
+    blockNumber,
+    weth: weth.address.toLowerCase(),
+    tokenAddresses: tokens.map(({ address }) => address.toLowerCase()),
+  }
+
   try {
     // Retrieve more info from The Graph's API
-    const response = await thegraphClient.request(TokenInfoQuery, {
-      weth: weth.address.toLowerCase(),
-      tokenAddresses: tokens.map(({ address }) => address.toLowerCase()),
-    })
+    const response = await thegraphClient.request(query, variables)
 
     const data = [
       // Merge response arrays
@@ -97,8 +126,9 @@ export async function addGraphInfo(tokens: Token[]): Promise<Token[]> {
       ...response?.tokensBA,
     ]
 
-    return addData(tokens, data)
+    return addData(tokens, data, historical)
   } catch (e) {
+    console.error(e)
     return tokens
   }
 }

--- a/state/meta.ts
+++ b/state/meta.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil'
+
+export const currentBlockNumberState = atom<number>({
+  key: 'currentBlockNumberState',
+  default: 0,
+})

--- a/types/trade.ts
+++ b/types/trade.ts
@@ -22,6 +22,7 @@ export interface UniSwapToken {
 export interface Token extends UniSwapToken {
   pairId: string | null
   price: number | null
+  priceHistorical: number | null
   priceChange: number | null
   liquidity: number | null
   logoColor: string | null
@@ -48,6 +49,16 @@ export interface PairByIdQueryResponse {
   }
 }
 
+export interface MetaQueryResponse {
+  _meta: {
+    block: {
+      hash: string
+      number: number
+    }
+    deployment: string
+  }
+}
+
 export type HandleBuyClick = (pairInfo: PairInfo) => void
 
 export type HandleSellClick = (pairInfo: PairInfo) => void
@@ -59,6 +70,9 @@ export type ResponsivelyHidable = {
   hideAbove?: keyof BreakPointOptions
 }
 
+export type ColorBasedOnValue = { colorBasedOnValue?: boolean }
+
 export type ListColumn<T extends Record<string, unknown>> = Column<T> &
   LeftOrRightAlignable &
-  ResponsivelyHidable
+  ResponsivelyHidable &
+  ColorBasedOnValue


### PR DESCRIPTION
fixes #49 

Uses an assumption of average block time of 15 seconds. Fetches data 5760 blocks before current block.

`(24 * 3600) / 15 = 5760 (blocks per 24h)`