### PR TITLE
Fix profit calculation issue

### DIFF
--- a/hooks/useUserPositions.ts
+++ b/hooks/useUserPositions.ts
@@ -183,7 +183,7 @@ function useUserPositions(): Token[] | null {
                 // Calculate profit percentage
                 const profitPercentage =
                   reward && profitablePrice && parsedAmountOut
-                    ? -(profitablePrice - parsedAmountOut) / parsedAmountOut
+                    ? -(profitablePrice - parsedAmountOut) / profitablePrice
                     : 0
 
                 // Parse the available VNL reward


### PR DESCRIPTION
There have been bug reports of losses of more than 100%, which obviously is not possible.

Category: "whoops"