### PR TITLE
Bug Bounty scoping clarifications and small fixes

### DIFF
--- a/pages/bug-bounty.mdx
+++ b/pages/bug-bounty.mdx
@@ -16,24 +16,22 @@ The Primary scope of the bug bounty program is for vulnerabilities affecting the
 - VanillaRouter deployed at [0xE13E9010e818D48df1A0415021d9526ef845e2Cd](https://etherscan.io/address/0xe13e9010e818d48df1a0415021d9526ef845e2cd)
 - VanillaGovernanceToken deployed at [0x1017B147b05942EAd495E2ad6d606EF3C94B8FD0](https://etherscan.io/address/0x1017b147b05942ead495e2ad6d606ef3c94b8fd0)
 
-All other contracts and deployments are excluded from the scope, including but not limited to:
+This list of addresses will change as the Vanilla Protocol evolves - as new contracts are taken into use or as existing contracts are displaced. Discovered vulnerabilities in any other contracts or deployments are excluded from the scope, including but not limited to:
 
 - Same contracts deployed in other addresses or networks (like testnets)
 - Other contracts in the Vanilla codebase (like test contracts)
 - Third-party contracts or platforms that interact with the Vanilla Protocol contracts (like smart contract wallets or exchanges)
 
-This list of addresses will change as the Vanilla Protocol evolves - as new contracts are taken into use or as existing contracts are displaced.
-
 The Secondary scope of the program is for vulnerabilities in the Vanilla Interface code that could likely result in an unauthorized exploitation of the users of Vanilla Trading Interface, hosted at https://vanilladefi.com/trade.
 
-All other user interfaces and third party interface code are excluded from the Secondary scope, including but not limited to:
+Discovered vulnerabilities in any other user interfaces or third-party interface code are excluded from the Secondary scope, including but not limited to:
 
-- All Vanilla trading interfaces hosted outside the vanilladefi.com domain
-- Third party wallet software
+- Any Vanilla-integrating interfaces hosted outside the vanilladefi.com domain
+- Any third-party software used with Vanilla Interface (like wallets)
 
 ## Rewards
 
-Vanilla offers substantial rewards for discoveries that can prevent the loss of assets, the freezing of assets, or harm to a user, commensurate with the severity, likelihood, and exploitability of the vulnerability. Vanilla will pay a reward of $500 to $10,000 for eligible discoveries in primary scope, and up to $2500 for eligible discoveries in secondary scope, according to the terms and conditions provided below.
+Vanilla offers substantial rewards for discoveries that can prevent the loss of assets, the freezing of assets, or harm to a user, commensurate with the severity, likelihood, and exploitability of the vulnerability. Vanilla will pay a reward of $500 to $10,000 for eligible discoveries in Primary scope, and up to $2500 for eligible discoveries in Secondary scope, according to the terms and conditions provided below.
 
 ## Disclosure
 


### PR DESCRIPTION
This PR adds few clarifications and fixes to Bug Bounty:

- the secondary scope now talks explicitly about "Vanilla Interface code" and "users of Vanilla interface hosted at vanilladefi.com/trade" - the intention here is to exclude the phishing, email scams, spamming, ddossing etc from the scope
- also, secondary scope now uses the qualifier "could likely" instead of "could conceivably", to exclude the interface vulnerabilities of small likelihood out of scope
- the reward categories for primary and secondary are split now
- few additions to terms, so that we shouldn't have to figure out Binance wallet user's USDC addresses anymore

