### PR TITLE
Migration state snapshot now uses correct block number

### DIFF
--- a/hooks/useTokenConversion.ts
+++ b/hooks/useTokenConversion.ts
@@ -90,7 +90,7 @@ export default function useTokenConversion(): {
           })
           setAllowance(formatUnits(balance, vnlDecimals))
         } catch (e) {
-          console.error(e)
+          console.error('Approve VNL1', e)
         }
       }
     }
@@ -104,7 +104,7 @@ export default function useTokenConversion(): {
       try {
         const parsedAllowance = parseUnits(allowance, vnlDecimals)
         if (!parsedAllowance.isZero()) {
-          const { getProof } = await snapshot(vnlToken1)
+          const { getProof } = await snapshot(vnlToken1, vnlToken2)
           const proof = getProof({
             amount: parsedAllowance,
             address: walletAddress,
@@ -129,7 +129,7 @@ export default function useTokenConversion(): {
           setAllowance(null)
         }
       } catch (e) {
-        console.error(e)
+        console.error('Convert VNL', e)
       }
     }
     return conversionReceipt
@@ -181,6 +181,7 @@ export default function useTokenConversion(): {
             if (VNLToken1 && VNLToken2 && !legacyBalance?.isZero()) {
               const { getProof, verify, root, snapshotState } = await snapshot(
                 VNLToken1,
+                VNLToken2,
               )
 
               // Get v1.0 token state snapshot
@@ -240,7 +241,7 @@ export default function useTokenConversion(): {
         }
       } catch (e) {
         nextConversionState = ConversionState.ERROR
-        console.error(e)
+        console.error('connect Tokens', e)
       }
 
       // Set the state


### PR DESCRIPTION
This PR fixes the issue of passing incorrect proof to `convertVNL` function.