### PR TITLE
Fix contract addresses in bug bounty

### DIFF
--- a/pages/bug-bounty.mdx
+++ b/pages/bug-bounty.mdx
@@ -13,8 +13,10 @@ Vanilla encourages the community to audit our contracts and security; we also en
 
 The Primary scope of the bug bounty program is for vulnerabilities affecting the _on-chain Vanilla Protocol_ which currently includes only the following Ethereum Mainnet contracts:
 
-- VanillaRouter deployed at [0xE13E9010e818D48df1A0415021d9526ef845e2Cd](https://etherscan.io/address/0xe13e9010e818d48df1a0415021d9526ef845e2cd)
-- VanillaGovernanceToken deployed at [0x1017B147b05942EAd495E2ad6d606EF3C94B8FD0](https://etherscan.io/address/0x1017b147b05942ead495e2ad6d606ef3c94b8fd0)
+- VanillaV1Router02 deployed at [0x72C8B3aA6eD2fF68022691ecD21AEb1517CfAEa6](https://etherscan.io/address/0x72c8b3aa6ed2ff68022691ecd21aeb1517cfaea6)
+- VanillaV1Token02 deployed at [0xbf900809f4C73e5a3476eb183d8b06a27e61F8E5](https://etherscan.io/address/0xbf900809f4c73e5a3476eb183d8b06a27e61f8e5)
+- VanillaV1MigrationState deployed at [0xB62726743Eec0573ec48457bDF02cB23F2387153](https://etherscan.io/address/0xb62726743eec0573ec48457bdf02cb23f2387153)
+- VanillaV1Safelist01 deployed at [0x2d0338725b04533Bf4f6D2b4c56F008613679517](https://etherscan.io/address/0x2d0338725b04533bf4f6d2b4c56f008613679517)
 
 This list of addresses will change as the Vanilla Protocol evolves - as new contracts are taken into use or as existing contracts are displaced. Discovered vulnerabilities in any other contracts or deployments are excluded from the scope, including but not limited to:
 


### PR DESCRIPTION
The Bug Bounty page had the v1 addresses, this PR updates them to v1.1